### PR TITLE
add the general case of M requests per N seconds

### DIFF
--- a/cuttle.yml
+++ b/cuttle.yml
@@ -14,8 +14,9 @@ addr: :3128
 zones:
   - host: "*"  # Apply to requests forwarded to all domains.
     shared: true  # The rate limit is shared by all domains.
-    control: rps  # Use request-per-second rate limit control.
-    rate: 2  # At most 2 requests per second in the entire zone.
+    control: rpns  # Use request-per-second rate limit control.
+    rate: 1  # At most 1 requests per N second in the entire zone.
+    nseconds: 3 # N second = 3
 
 # Example - Only throttle *.github.com and no rate limit on other domains.
 #

--- a/cuttle/zone.go
+++ b/cuttle/zone.go
@@ -29,14 +29,14 @@ type Zone struct {
 	Control string
 	// Rate specifies the rate of the rate limit controller.
 	Rate int
-
+    Nseconds int
 	controllers map[string]LimitController
 }
 
 // NewZone returns a new Zone given the configurations.
-func NewZone(host string, path string, limitby string, shared bool, control string, rate int) *Zone {
+func NewZone(host string, path string, limitby string, shared bool, control string, rate int, nseconds int) *Zone {
 	return &Zone{
-		host, path, limitby, shared, control, rate,
+		host, path, limitby, shared, control, rate, nseconds,
 		make(map[string]LimitController),
 	}
 }
@@ -102,6 +102,8 @@ func (z *Zone) GetController(host string, path string) LimitController {
 			controller = NewRPSControl(key, z.Rate)
 		case "rpm":
 			controller = NewRPMControl(key, z.Rate)
+        case "rpns":
+			controller = NewRPNSControl(key, z.Rate, z.Nseconds)
 		case "noop":
 			controller = NewNoopControl(key)
 		case "ban":

--- a/main.go
+++ b/main.go
@@ -55,11 +55,15 @@ func main() {
 		if c.LimitBy == "" {
 			c.LimitBy = "host"
 		}
+        
+        if c.Nseconds == 0 {
+            c.Nseconds = 1
+        }
 
-		log.Debugf("ZoneConfig: host - %s, path - %s, limitby - %s, shared - %t, control - %s, rate - %d",
-			c.Host, c.Path, c.LimitBy, c.Shared, c.Control, c.Rate)
+		log.Debugf("ZoneConfig: host - %s, path - %s, limitby - %s, shared - %t, control - %s, rate - %d, nseconds - %d",
+			c.Host, c.Path, c.LimitBy, c.Shared, c.Control, c.Rate, c.Nseconds)
 
-		zones[i] = *cuttle.NewZone(c.Host, c.Path, c.LimitBy, c.Shared, c.Control, c.Rate)
+		zones[i] = *cuttle.NewZone(c.Host, c.Path, c.LimitBy, c.Shared, c.Control, c.Rate, c.Nseconds)
 	}
 
 	// Config CA Cert.
@@ -130,10 +134,11 @@ type Config struct {
 }
 
 type ZoneConfig struct {
-	Host    string
-	Path    string // Optional, default "/"
-	LimitBy string // Optional, default "host"
-	Shared  bool   // Optional, default "false"
-	Control string
-	Rate    int
+	Host     string
+	Path     string // Optional, default "/"
+	LimitBy  string // Optional, default "host"
+	Shared   bool   // Optional, default "false"
+	Control  string
+	Rate     int
+    Nseconds int    // Optional, default "1"
 }


### PR DESCRIPTION
the general case of M requests per N seconds is added. For example, Nseconds=60 would be the same as RPM, and Nseconds=1 would be the same as RPS. 