### PR TITLE
Changing the case of this import

### DIFF
--- a/cuttle/limitcontrol.go
+++ b/cuttle/limitcontrol.go
@@ -4,7 +4,7 @@ import (
 	"container/list"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // LimitController defines behaviors of a rate limit control.

--- a/cuttle/zone.go
+++ b/cuttle/zone.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // A Zone holds the settings and states of the rate limited location(s).

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,5 +1,5 @@
 package: main
 import:
   - package: github.com/elazarl/goproxy
-  - package: github.com/Sirupsen/logrus
+  - package: github.com/sirupsen/logrus
   - package: gopkg.in/yaml.v2

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"os"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/elazarl/goproxy"
 	yaml "gopkg.in/yaml.v2"
 


### PR DESCRIPTION
Hey! So I went to install this using the official instructions

```
GOPATH=`pwd` go get github.com/mrkschan/cuttle
```

and it kicked out with this error

```
go: downloading github.com/mrkschan/cuttle v0.0.0-20180228170030-d4c681411595
go: finding module for package gopkg.in/yaml.v2
go: finding module for package github.com/elazarl/goproxy
go: finding module for package github.com/Sirupsen/logrus
go: downloading github.com/elazarl/goproxy v0.0.0-20220417044921-416226498f94
go: downloading github.com/Sirupsen/logrus v1.8.1
go: downloading gopkg.in/yaml.v2 v2.4.0
go: found github.com/Sirupsen/logrus in github.com/Sirupsen/logrus v1.8.1
go: found github.com/elazarl/goproxy in github.com/elazarl/goproxy v0.0.0-20220417044921-416226498f94
go: found gopkg.in/yaml.v2 in gopkg.in/yaml.v2 v2.4.0
go: github.com/mrkschan/cuttle imports
   github.com/Sirupsen/logrus: github.com/Sirupsen/logrus@v1.8.1: parsing go.mod:
   module declares its path as: github.com/sirupsen/logrus
           but was required as: github.com/Sirupsen/logrus
```

It fixes it by just moving from an uppercase letter to a lowercase one. Think we can get this merged in?